### PR TITLE
Additional objectives for pyomo models

### DIFF
--- a/electric_emission_cost/costs.py
+++ b/electric_emission_cost/costs.py
@@ -926,6 +926,7 @@ def calculate_cost(
     desired_charge_type=None,
     demand_scale_factor=1,
     model=None,
+    additional_objective_terms=None,
     varstr_alias_func=default_varstr_alias_func,
 ):
     """Calculates the cost of given charges (demand or energy) for the given
@@ -994,6 +995,11 @@ def calculate_cost(
 
     model : pyomo.Model
         The model object associated with the problem.
+        Only used in the case of Pyomo, so `None` by default.
+
+    additional_objective_terms : pyomo.Expression, list
+        Additional terms to be added to the objective function.
+        Can be a single pyomo Expression or a list of pyomo Expressions.
         Only used in the case of Pyomo, so `None` by default.
 
     varstr_alias_func: function
@@ -1117,6 +1123,12 @@ def calculate_cost(
             cost += charge_array.sum()
         else:
             raise ValueError("Invalid charge_type: " + charge_type)
+
+    if additional_objective_terms is not None:
+        if len(additional_objective_terms) > 1:
+            cost += sum(additional_objective_terms)
+        else:
+            cost += additional_objective_terms
     return cost, model
 
 

--- a/electric_emission_cost/costs.py
+++ b/electric_emission_cost/costs.py
@@ -926,7 +926,6 @@ def calculate_cost(
     desired_charge_type=None,
     demand_scale_factor=1,
     model=None,
-    additional_objective_terms=None,
     varstr_alias_func=default_varstr_alias_func,
 ):
     """Calculates the cost of given charges (demand or energy) for the given
@@ -1124,12 +1123,146 @@ def calculate_cost(
         else:
             raise ValueError("Invalid charge_type: " + charge_type)
 
-    if additional_objective_terms is not None:
-        if len(additional_objective_terms) > 1:
-            cost += sum(additional_objective_terms)
-        else:
-            cost += additional_objective_terms
     return cost, model
+
+def build_pyomo_costing(
+    charge_dict,
+    consumption_data_dict,
+    model,
+    electric_consumption_units=u.kW,
+    gas_consumption_units=u.meters**3 / u.day,
+    resolution="15m",
+    prev_demand_dict=None,
+    prev_consumption_dict=None,
+    consumption_estimate=0,
+    desired_utility=None,
+    desired_charge_type=None,
+    demand_scale_factor=1,
+    additional_objective_terms=None,
+    varstr_alias_func=default_varstr_alias_func,
+    ):
+    """
+    Wrapper for calculate_cost to build the cost components into a Pyomo model.
+
+    Parameters
+    ----------
+    charge_dict : dict
+        dictionary of arrays with keys of the form
+        `utility`_`charge_type`_`name`_`start_date`_`end_date`_`charge_limit`
+        and values being the $ per kW (electric demand), kWh (electric energy/export),
+        cubic meter / day (gas demand), cubic meter (gas energy),
+        or $ / month (customer)
+
+    consumption_data_dict : dict
+        Baseline electrical and gas usage data as an optimization variable object
+        with keys "electric" and "gas". Values of the dictionary must be of type
+        numpy.ndarray, cvxpy.Expression, or pyomo.environ.Var
+
+    model : pyomo.Model
+        The model object associated with the problem.
+
+    electric_consumption_units : pint.Unit
+        Units for the electricity consumption data. Default is kW
+
+    gas_consumption_units : pint.Unit
+        Units for the natural gas consumption data. Default is cubic meters / day
+
+    resolution : str
+        String of the form `[int][str]` giving the temporal resolution
+        on which charges are assessed, the `str` portion corresponds to
+        numpy.timedelta64 types for example '15m' specifying demand charges
+        that are applied to 15-minute intervals of electricity consumption
+
+    prev_demand_dict : dict
+        Nested dictionary previous maximmum demand charges with an entry of the form
+        {"cost" : float, "demand" : float} for each charge.
+        Default is None, which results in an a prev_demand and prev_demand_cost
+        of zero for all charges.
+
+    prev_consumption_dict : dict
+        Dictionary of previous total energy consumption with a key for each charge
+        to be used when starting the cost calculation partway into a billing period
+        (e.g., while using a moving horizon that is shorter than a month).
+        Default is None, resulting in an a prev_consumption of zero for all charges.
+
+    consumption_estimate : float
+        Estimate of the total monthly demand or energy consumption from baseline data.
+        Only used when `consumption_data` is cvxpy.Expression or pyomo.environ.Var
+        for convex relaxation of tiered charges, while numpy.ndarray `consumption_data`
+        will use actual consumption and ignore the estimate.
+
+    desired_charge_type : list or str
+        Name of desired charge type for itemized costs.
+        Either 'customer', 'energy', 'demand', 'export', or a list of charge types.
+        Default is None, meaning that all costs will be summed together.
+
+    desired_utility : list or str
+        Name of desired utility for itemized costs.
+        Either 'electric', 'gas', or a list of utilities (e.g., ['electric', 'gas']).
+        Default is None, meaning that all costs will be summed together.
+
+    demand_scale_factor : float
+        Optional factor for scaling demand charges relative to energy charges
+        when the optimization/simulation period is not a full billing cycle.
+        Applied to monthly charges where end_date - start_date > 1 day.
+        Default is 1
+
+    additional_objective_terms : list
+        Additional terms to be added to the objective function. 
+        Must be a list of pyomo Expressions.
+
+    varstr_alias_func: function
+        Function to generate variable name for pyomo,
+        should take in a 6 inputs and generate a string output.
+        The function will receive following six inputs:
+
+        - utility: str
+        - charge_type: str
+        - name: str
+        - start_date: str
+        - end_date: str
+        - charge_limit: str
+
+        Examples of functions:
+            f_no_dates=lambda utility,
+            charge_type, name,
+            start_date, end_date,
+            charge_limit:
+            f"{utility}_{charge_type}_{name}_{charge_limit}"
+
+    Raises
+    ------
+    ValueError
+        When invalid `utility`, `charge_type`, or `assessed`
+        is provided in `charge_arrays`
+
+    Returns
+    -------
+    pyomo.Model
+        The model object associated with the problem with costing components added.
+    """
+    model.electricity_cost, model = calculate_cost(
+            charge_dict=charge_dict,
+            consumption_data_dict=consumption_data_dict,
+            electric_consumption_units=electric_consumption_units,
+            gas_consumption_units=gas_consumption_units,
+            resolution=resolution,
+            prev_demand_dict=prev_demand_dict,
+            prev_consumption_dict=prev_consumption_dict,
+            consumption_estimate=consumption_estimate,
+            desired_utility=desired_utility,
+            desired_charge_type=desired_charge_type,
+            demand_scale_factor=demand_scale_factor,
+            model=model,
+            varstr_alias_func=varstr_alias_func
+    )
+
+    model.obj = pyo.Objective(expr=model.electricity_cost, sense=pyo.minimize)
+
+    if additional_objective_terms is not None:
+        for term in additional_objective_terms:
+            model.obj.expr += term
+    return model
 
 
 def calculate_itemized_cost(

--- a/electric_emission_cost/costs.py
+++ b/electric_emission_cost/costs.py
@@ -1125,6 +1125,7 @@ def calculate_cost(
 
     return cost, model
 
+
 def build_pyomo_costing(
     charge_dict,
     consumption_data_dict,
@@ -1140,7 +1141,7 @@ def build_pyomo_costing(
     demand_scale_factor=1,
     additional_objective_terms=None,
     varstr_alias_func=default_varstr_alias_func,
-    ):
+):
     """
     Wrapper for calculate_cost to build the cost components into a Pyomo model.
 
@@ -1208,7 +1209,7 @@ def build_pyomo_costing(
         Default is 1
 
     additional_objective_terms : list
-        Additional terms to be added to the objective function. 
+        Additional terms to be added to the objective function.
         Must be a list of pyomo Expressions.
 
     varstr_alias_func: function
@@ -1242,19 +1243,19 @@ def build_pyomo_costing(
         The model object associated with the problem with costing components added.
     """
     model.electricity_cost, model = calculate_cost(
-            charge_dict=charge_dict,
-            consumption_data_dict=consumption_data_dict,
-            electric_consumption_units=electric_consumption_units,
-            gas_consumption_units=gas_consumption_units,
-            resolution=resolution,
-            prev_demand_dict=prev_demand_dict,
-            prev_consumption_dict=prev_consumption_dict,
-            consumption_estimate=consumption_estimate,
-            desired_utility=desired_utility,
-            desired_charge_type=desired_charge_type,
-            demand_scale_factor=demand_scale_factor,
-            model=model,
-            varstr_alias_func=varstr_alias_func
+        charge_dict=charge_dict,
+        consumption_data_dict=consumption_data_dict,
+        electric_consumption_units=electric_consumption_units,
+        gas_consumption_units=gas_consumption_units,
+        resolution=resolution,
+        prev_demand_dict=prev_demand_dict,
+        prev_consumption_dict=prev_consumption_dict,
+        consumption_estimate=consumption_estimate,
+        desired_utility=desired_utility,
+        desired_charge_type=desired_charge_type,
+        demand_scale_factor=demand_scale_factor,
+        model=model,
+        varstr_alias_func=varstr_alias_func,
     )
 
     model.obj = pyo.Objective(expr=model.electricity_cost, sense=pyo.minimize)

--- a/electric_emission_cost/tests/test_costs.py
+++ b/electric_emission_cost/tests/test_costs.py
@@ -869,7 +869,7 @@ def test_calculate_cost_pyo(
             "single",
             pytest.approx(270),
         ),
-                # energy charge with charge limit
+        # energy charge with charge limit
         (
             {
                 "electric_energy_all-day_2024-07-10_2024-07-10_0": np.concatenate(
@@ -947,6 +947,7 @@ def test_build_pyomo_costing(
     assert model is not None
     assert model.obj is not None
     assert pyo.value(model.obj) == expected_cost
+
 
 @pytest.mark.skipif(skip_all_tests, reason="Exclude all tests")
 @pytest.mark.parametrize(

--- a/electric_emission_cost/tests/test_costs.py
+++ b/electric_emission_cost/tests/test_costs.py
@@ -843,6 +843,113 @@ def test_calculate_cost_pyo(
 
 @pytest.mark.skipif(skip_all_tests, reason="Exclude all tests")
 @pytest.mark.parametrize(
+    "charge_dict, consumption_data_dict, consumption_estimate, "
+    "additional_objective_type, expected_cost",
+    [
+        # energy charge with charge limit
+        (
+            {
+                "electric_energy_all-day_2024-07-10_2024-07-10_0": np.concatenate(
+                    [
+                        np.ones(64) * 0.05,
+                        np.ones(20) * 0.1,
+                        np.ones(12) * 0.05,
+                    ]
+                ),
+                "electric_energy_all-day_2024-07-10_2024-07-10_100": np.concatenate(
+                    [
+                        np.ones(64) * 0.1,
+                        np.ones(20) * 0.15,
+                        np.ones(12) * 0.1,
+                    ]
+                ),
+            },
+            {ELECTRIC: np.ones(96) * 100, GAS: np.ones(96)},
+            2400,
+            "single",
+            pytest.approx(270),
+        ),
+                # energy charge with charge limit
+        (
+            {
+                "electric_energy_all-day_2024-07-10_2024-07-10_0": np.concatenate(
+                    [
+                        np.ones(64) * 0.05,
+                        np.ones(20) * 0.1,
+                        np.ones(12) * 0.05,
+                    ]
+                ),
+                "electric_energy_all-day_2024-07-10_2024-07-10_100": np.concatenate(
+                    [
+                        np.ones(64) * 0.1,
+                        np.ones(20) * 0.15,
+                        np.ones(12) * 0.1,
+                    ]
+                ),
+            },
+            {ELECTRIC: np.ones(96) * 100, GAS: np.ones(96)},
+            2400,
+            "multiple",
+            pytest.approx(270),
+        ),
+    ],
+)
+def test_build_pyomo_costing(
+    charge_dict,
+    consumption_data_dict,
+    consumption_estimate,
+    additional_objective_type,
+    expected_cost,
+):
+    model = pyo.ConcreteModel()
+    model.T = len(consumption_data_dict["electric"])
+    model.t = range(model.T)
+
+    # the expression must be on the model so it can't be passed externally
+    if additional_objective_type == "single":
+        model.x = pyo.Expression(expr=10)
+        additional_objective_terms = [model.x]
+    elif additional_objective_type == "multiple":
+        model.x = pyo.Expression(expr=10)
+        model.y = pyo.Expression(expr=0)
+        additional_objective_terms = [model.x, model.y]
+    else:
+        pass
+
+    pyo_vars = {}
+    for key, val in consumption_data_dict.items():
+        var = pyo.Var(range(len(val)), initialize=np.zeros(len(val)), bounds=(0, None))
+        model.add_component(key, var)
+        pyo_vars[key] = var
+
+    @model.Constraint(model.t)
+    def electric_constraint(m, t):
+        return consumption_data_dict["electric"][t] == m.electric[t]
+
+    @model.Constraint(model.t)
+    def gas_constraint(m, t):
+        return consumption_data_dict["gas"][t] == m.gas[t]
+
+    model = costs.build_pyomo_costing(
+        charge_dict,
+        pyo_vars,
+        model=model,
+        resolution="15m",
+        prev_demand_dict=None,
+        consumption_estimate=consumption_estimate,
+        desired_utility=None,
+        desired_charge_type=None,
+        additional_objective_terms=additional_objective_terms,
+    )
+    solver = pyo.SolverFactory("gurobi")
+    solver.solve(model)
+
+    assert model is not None
+    assert model.obj is not None
+    assert pyo.value(model.obj) == expected_cost
+
+@pytest.mark.skipif(skip_all_tests, reason="Exclude all tests")
+@pytest.mark.parametrize(
     "start_dt, end_dt, billing_data, utility, consumption_data_dict, "
     "prev_demand_dict, consumption_estimate, scale_factor, expected",
     [


### PR DESCRIPTION
**Pull request recommendations:**
Creates a wrapper around calculate costs that also includes adding other model expressions to the objective function (as long as they are already built on the model).

Addresses issue #38.