### PR TITLE
Add unit tests for get_freq_binsize_minutes

### DIFF
--- a/eeco/tests/test_utils.py
+++ b/eeco/tests/test_utils.py
@@ -19,6 +19,29 @@ def test_parse_freq(freq, expected):
 
 @pytest.mark.skipif(skip_all_tests, reason="Exclude all tests")
 @pytest.mark.parametrize(
+    "freq, expected",
+    [
+        ("15m", 15),
+        ("1m", 1),
+        ("1h", 60),
+        ("6h", 360),
+        ("1D", 1440),
+        ("1d", 1440),
+        ("2d", 2880),
+    ],
+)
+def test_get_freq_binsize_minutes(freq, expected):
+    assert ut.get_freq_binsize_minutes(freq) == expected
+
+
+@pytest.mark.skipif(skip_all_tests, reason="Exclude all tests")
+def test_get_freq_binsize_minutes_invalid_type_raises():
+    with pytest.raises(ValueError):
+        ut.get_freq_binsize_minutes("1y")
+
+
+@pytest.mark.skipif(skip_all_tests, reason="Exclude all tests")
+@pytest.mark.parametrize(
     "consumption_data, varstr, expected",
     [
         ({"electric": np.ones(96) * 100, "gas": np.ones(96)}, "electric", 9600),


### PR DESCRIPTION
Fixes #61

`get_freq_binsize_minutes` was only covered indirectly through other tests that wrap it. This adds direct unit tests, following the same parametrized style as the neighboring `test_parse_freq`: minute/hour/day resolutions (both `D` and `d`), and the `ValueError` raised for an unsupported resolution type.

`pytest eeco/tests/test_utils.py -k freq` — 10 passed. `flake8`/`black --check` clean on the changed file. (The rest of `test_utils.py` needs the SCIP/IPOPT solvers from the conda CI setup, which aren't available in the environment I tested in, so I only ran the freq-related subset plus the full file to confirm nothing else regressed.)